### PR TITLE
Support returning table from formatters

### DIFF
--- a/lua/lsp-progress.lua
+++ b/lua/lsp-progress.lua
@@ -23,7 +23,7 @@ local DEFAULTS = {
             has_title = true
         end
         if message and message ~= "" then
-            table.insert(builder, self.message)
+            table.insert(builder, message)
             has_message = true
         end
         if percentage and (has_title or has_message) then
@@ -108,6 +108,7 @@ function LoggerCls:log(level, msg)
     end
     local traceinfo = debug.getinfo(2, "Sl")
     local lineinfo = traceinfo.short_src .. ":" .. traceinfo.currentline
+  ---@diagnostic disable-next-line: missing-parameter
     local split_msg = vim.split(msg, "\n")
 
     local function log_format(c, s)
@@ -130,11 +131,13 @@ function LoggerCls:log(level, msg)
     end
     if self.file then
         local fp = io.open(self.filename, "a")
-        for _, m in ipairs(split_msg) do
-            fp:write(log_format(self.counter, m) .. "\n")
+        if fp ~= nil then
+            for _, m in ipairs(split_msg) do
+                fp:write(log_format(self.counter, m) .. "\n")
+            end
+            fp:close()
+          end
         end
-        fp:close()
-    end
     self.counter = self.counter + 1
 end
 
@@ -490,7 +493,7 @@ local function progress()
             local series_messages = {}
             for _, series in pairs(deduped_serieses) do
                 local msg = CONFIG.series_format(series.title, series.message, series.percentage, series.done)
-                LOGGER:debug("Get series msg (client_id:" .. client_id .. ") in progress: " .. msg)
+                LOGGER:debug("Get series msg (client_id:" .. client_id .. ") in progress: " .. vim.inspect(msg))
                 table.insert(series_messages, msg)
             end
             local clientmsg = CONFIG.client_format(


### PR DESCRIPTION
### Changes

- Fix stray `self`
- Add one diagnostic ignore
- Check for nil file pointer
- Don't assume series_format returns a string

### Example usage

This is my lazy.nvim/packer config for the plugin 
I am returning table|nil from series_format and client_format
Ultimately the result for calling `lspprogress.progress()` is something like ` ◣ sumneko_lua, null-ls ` (spinner, comma separated lsp names)

https://user-images.githubusercontent.com/609213/218289953-47581d45-2be3-4cbf-8f73-c9c607b330e1.mp4

```lua
    config = function()
      local function series_format(title, message, percentage, done)
        if done then
          return nil
        end
        return {
          title = title,
          message = message,
          percentage = percentage,
          done = done,
        }
      end

      ---@class ClientMessage
      ---@field spinner string
      ---@field client_name string
      ---@field title string
      ---@field message string
      ---@field percentage number

      ---@param client_name string
      ---@param spinner string
      ---@param series_messages table
      ---@return ClientMessage|nil passed to format as item in client_messages[]
      local function client_format(client_name, spinner, series_messages)
        series_messages = vim.tbl_filter(function(t)
          return t ~= nil
        end, series_messages)
        if #series_messages > 0 then
          return {
            spinner = spinner,
            client_name = client_name,
            title = series_messages[1].title,
            message = series_messages[1].message,
            percentage = series_messages[1].percentage,
          }
        end
        return nil
      end

      ---@param client_messages ClientMessage[]
      ---@return string that is output when calling .progress()
      local function format(client_messages)
        client_messages = vim.tbl_filter(function(t)
          return t ~= nil
        end, client_messages)
        if #client_messages == 0 then
          return ""
        end

        local spinner = client_messages[1].spinner
        local clients = {}
        for _, client_message in ipairs(client_messages) do
          table.insert(clients, client_message.client_name)
        end
        local joinedClients = table.concat(clients, ", ")
        local clientsString = joinedClients

        -- spinner, space, busy client names
        return spinner .. " " .. clientsString
      end

      require("lsp-progress").setup({
        series_format = series_format,
        client_format = client_format,
        format = format,
        spinner = { "◢", "◣", "◤", "◥" },
      })
    end,
  },
```