### PR TITLE
perf: cache deduped series

### DIFF
--- a/lua/lsp-progress.lua
+++ b/lua/lsp-progress.lua
@@ -145,7 +145,8 @@ local function progress_handler(err, msg, ctx)
     local client = get_client(client_id)
     if value.kind == "begin" then
         -- add task
-        local series = new_series(value.title, value.message, value.percentage)
+        local series =
+            new_series(token, value.title, value.message, value.percentage)
         client:add_series(token, series)
         -- start spin, it will also notify user at a fixed rate
         spin(client_id, token)

--- a/lua/lsp-progress/client.lua
+++ b/lua/lsp-progress/client.lua
@@ -3,6 +3,60 @@ local logger = require("lsp-progress.logger")
 local ClientFormatter = nil
 local Spinner = nil
 
+local DedupedSeriesCacheObject = {
+    token = nil,
+    all_tokens = {},
+    count = nil,
+}
+
+local function new_deduped_series_cache_object()
+    local cache = vim.tbl_extend(
+        "force",
+        vim.deepcopy(DedupedSeriesCacheObject),
+        { count = 0 }
+    )
+    return cache
+end
+
+function DedupedSeriesCacheObject:add_dedup(client, series)
+    local token = series.token
+    if not client:has_series(token) then
+        self.token = token
+        self.all_tokens[token] = true
+        self.count = self.count + 1
+    else
+        local old_series = client:get_series(token)
+        if series:less_than(old_series) then
+            self.token = token
+        end
+        self.all_tokens[token] = true
+        self.count = self.count + 1
+    end
+end
+
+function DedupedSeriesCacheObject:remove_dedup(client, series)
+    local token = series.token
+    if self.all_tokens[token] then
+        self.all_tokens[token] = nil
+        self.count = vim.fn.max(self.count - 1, 0)
+        local min_priority = nil
+        local min_token = nil
+        for t, v in pairs(self.all_tokens) do
+            if t and v and client:has_series(t) then
+                local next_series = client:get_series(t)
+                if
+                    min_priority == nil
+                    or next_series:priority() < min_priority
+                then
+                    min_priority = next_series:priority()
+                    min_token = t
+                end
+            end
+        end
+        self.token = min_token
+    end
+end
+
 local ClientObject = {
     client_id = nil,
     client_name = nil,
@@ -11,13 +65,42 @@ local ClientObject = {
 
     -- format cache
     _format_cache = nil,
+    -- deduped series cache
+    _deduped_serieses_cache = {},
 }
+
+function ClientObject:_has_deduped_series(key)
+    return self._deduped_serieses_cache[key] ~= nil
+end
+
+function ClientObject:_get_deduped_series(key)
+    return self._deduped_serieses_cache[key]
+end
+
+function ClientObject:_add_deduped_series(key)
+    self._deduped_serieses_cache[key] = new_deduped_series_cache_object()
+end
+
+function ClientObject:_remove_deduped_series(key)
+    self._deduped_serieses_cache[key] = nil
+end
 
 function ClientObject:has_series(token)
     return self.serieses[token] ~= nil
 end
 
 function ClientObject:remove_series(token)
+    if self:has_series(token) then
+        local series = self:get_series(token)
+        local key = series.key
+        if self:_has_deduped_series(key) then
+            local deduped_series = self:_get_deduped_series(key)
+            deduped_series:remove_dedup(self, series)
+            if deduped_series.count <= 0 then
+                self:_remove_deduped_series(key)
+            end
+        end
+    end
     self.serieses[token] = nil
     self:format()
 end
@@ -27,6 +110,16 @@ function ClientObject:get_series(token)
 end
 
 function ClientObject:add_series(token, series)
+    if not self:has_series(token) then
+        local key = series.key
+        if not self:_has_deduped_series(key) then
+            local deduped_series = self:_get_deduped_series(key)
+            deduped_series:remove_dedup(self, series)
+            if deduped_series.count <= 0 then
+                self:_remove_deduped_series(key)
+            end
+        end
+    end
     self.serieses[token] = series
     self:format()
 end
@@ -49,22 +142,6 @@ end
 
 function ClientObject:tostring()
     return string.format("[%s-%d]", self.client_name, self.client_id)
-end
-
--- if s1 is higher priority than s2
-local function higher_priority(s1, s2)
-    -- s1 has no percentage, so it's higher priority
-    if s1.percentage == nil then
-        return true
-    end
-
-    -- s2 has no percentage, so it's higher priority
-    if s2.percentage == nil then
-        return false
-    end
-
-    -- both s1 and s2 has percentage, lower percentage has higher priority
-    return s1.percentage < s2.percentage
 end
 
 function ClientObject:format()

--- a/lua/lsp-progress/series.lua
+++ b/lua/lsp-progress/series.lua
@@ -31,21 +31,6 @@ function SeriesObject:key()
     return self.key
 end
 
-function SeriesObject:less_than(other)
-    -- if self has no percentage, then self is lower
-    if self.percentage == nil then
-        return true
-    end
-
-    -- if other has no percentage, then other is lower
-    if other.percentage == nil then
-        return false
-    end
-
-    -- both self and other has percentage, then lower percentage is lower
-    return self.percentage < other.percentage
-end
-
 function SeriesObject:priority()
     if self.percentage == nil then
         return -1

--- a/lua/lsp-progress/series.lua
+++ b/lua/lsp-progress/series.lua
@@ -1,4 +1,5 @@
 local SeriesObject = {
+    token = nil,
     title = nil,
     message = nil,
     percentage = nil,
@@ -6,6 +7,9 @@ local SeriesObject = {
 
     -- format cache
     _format_cache = nil,
+
+    -- key
+    key = nil,
 }
 
 local SeriesFormatter = nil
@@ -24,7 +28,30 @@ function SeriesObject:finish(message)
 end
 
 function SeriesObject:key()
-    return tostring(self.title) .. "-" .. tostring(self.message)
+    return self.key
+end
+
+function SeriesObject:less_than(other)
+    -- if self has no percentage, then self is lower
+    if self.percentage == nil then
+        return true
+    end
+
+    -- if other has no percentage, then other is lower
+    if other.percentage == nil then
+        return false
+    end
+
+    -- both self and other has percentage, then lower percentage is lower
+    return self.percentage < other.percentage
+end
+
+function SeriesObject:priority()
+    if self.percentage == nil then
+        return -1
+    else
+        return self.percentage
+    end
 end
 
 function SeriesObject:_format()
@@ -36,13 +63,15 @@ function SeriesObject:format_result()
     return self._format_cache
 end
 
-local function new_series(title, message, percentage)
+local function new_series(token, title, message, percentage)
     local series = vim.tbl_extend("force", vim.deepcopy(SeriesObject), {
+        token = token,
         title = title,
         message = message,
         percentage = percentage,
         done = false,
     })
+    series.key = tostring(title) .. "-" .. tostring(message)
     series:_format()
     return series
 end


### PR DESCRIPTION
1. Cache deduped series to reduce CPU work, for better performance.
2. Add `DedupedSeriesCacheObject` data class.
3. Add `priority` API to `series`, for easier series comparison when dedup.