### PR TITLE
fix: wrong argument types passed to vim.fn.max

### DIFF
--- a/lua/lsp-progress.lua
+++ b/lua/lsp-progress.lua
@@ -238,7 +238,7 @@ local function progress()
             content = vim.fn.strcharpart(
                 content,
                 0,
-                vim.fn.max(Config.max_size - 1, 0)
+                vim.fn.max({ Config.max_size - 1, 0 })
             ) .. "…"
         end
     end


### PR DESCRIPTION
1. fix wrong argument types (must be an array) passed to `vim.fn.max`(relate issue #19).