### PR TITLE
fix: correct lua autocmd API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ require("lualine").setup({
 
 -- listen lsp-progress event and refresh lualine
 vim.api.nvim_create_augroup("lualine_augroup", { clear = true })
-vim.api.nvim_create_autocmd("User LspProgressStatusUpdated", {
+vim.api.nvim_create_autocmd("User", {
     group = "lualine_augroup",
+    pattern = "LspProgressStatusUpdated",
     callback = require("lualine").refresh,
 })
 ```

--- a/lua/lsp-progress/event.lua
+++ b/lua/lsp-progress/event.lua
@@ -109,7 +109,7 @@ local function emit()
             GlobalDisabledEventOptsManager == nil
             or not GlobalDisabledEventOptsManager:match()
         then
-            vim.cmd("doautocmd User " .. Configs.name)
+            vim.cmd("doautocmd <nomodeline> User " .. Configs.name)
             Configs.emit = true
             logger.debug("Emit user event:%s", Configs.name)
         else

--- a/test/minimal_neodev_init.lua
+++ b/test/minimal_neodev_init.lua
@@ -68,8 +68,9 @@ local plugins = {
             require("lualine").setup(opts)
 
             vim.api.nvim_create_augroup("lualine_augroup", { clear = true })
-            vim.api.nvim_create_autocmd("User LspProgressStatusUpdated", {
+            vim.api.nvim_create_autocmd("User", {
                 group = "lualine_augroup",
+                pattern = "LspProgressStatusUpdated",
                 callback = require("lualine").refresh,
             })
         end,


### PR DESCRIPTION
Current example will match all "User" events: https://github.com/neovim/neovim/issues/25517

Also, it will trigger all modelines, which means for example all folds will be continuously closed: https://github.com/vim/vim/issues/13291