### PR TITLE
fix: Escapes percentages in LSP progress messages

### DIFF
--- a/lua/lsp-progress/defaults.lua
+++ b/lua/lsp-progress/defaults.lua
@@ -84,7 +84,8 @@ local Defaults = {
             has_title = true
         end
         if message and string.len(message) then
-            table.insert(builder, message)
+            local escaped = vim.pesc(message)
+            table.insert(builder, escaped)
             has_message = true
         end
         if percentage and (has_title or has_message) then


### PR DESCRIPTION
A trio I use (Ruby LSP, Solargraph and RuboCop) is sending messages through LSP progress triggering an error like `E539: Illegal character < >`. 

I did some debugging and found out when the `message` in the `series_format` contains a `%` it needs to be escaped.

For example, when in the `series_format`, if the message is `100% completed`, the space right afer the `%` triggers the  `E539: Illegal character < >` because the end result sent to Neovim would be:

```
%#lualine_a_normal# NORMAL %#lualine_transitional_lualine_a_normal_to_lualine_b_normal#%#lualine_b_normal#  sdp-migration/low-install-checks-to-prod %#lualine_transitional_lualine_b_normal_to_lualine_c_filetype_DevIconRb_normal#%<%#lualine_c_filetype_DevIconRb_normal# %#lualine_c_normal# ruby %#lualine_c_normal#%#lualine_c_normal#  app/jobs/trust_automation/install_check_ingestion_job.rb %#lualine_c_normal#%=%#lualine_c_normal#  LSP [ruby_ls] ⣟ Ruby LSP: indexing files 100% completed (100%%) - done %#lualine_c_normal#  %#lualine_c_normal# utf-8 %#lualine_transitional_lualine_a_normal_to_lualine_c_normal#%#lualine_a_normal#   1:1  %#lualine_a_normal# Top 
```

Notice that in `Ruby LSP: indexing files 100% completed (100%%)` the second `%` is escaped, but the first one is not.

This should help get Ruby LSP going, as well as other LSP that uses `%` in the messages themselves.



