### PR TITLE
fix(format): don't use 'string.format' when formatting

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,4 +1,4 @@
 {
   "diagnostics.globals": ["vim", "describe", "before_each", "it"],
-  "workspace.checkThirdParty": false
+  "workspace.checkThirdParty": "Disable"
 }

--- a/lua/lsp-progress/defaults.lua
+++ b/lua/lsp-progress/defaults.lua
@@ -84,8 +84,7 @@ local Defaults = {
             has_title = true
         end
         if type(message) == "string" and string.len(message) > 0 then
-            local escaped = message:gsub("%%", "%%%%")
-            table.insert(builder, escaped)
+            table.insert(builder, message)
             has_message = true
         end
         if percentage and (has_title or has_message) then
@@ -113,12 +112,10 @@ local Defaults = {
     ---     `client_messages` array, or ignored if return nil.
     client_format = function(client_name, spinner, series_messages)
         return #series_messages > 0
-                and string.format(
-                    "[%s] %s %s",
-                    client_name,
-                    spinner,
-                    table.concat(series_messages, ", ")
-                )
+                and ("[" .. client_name .. "] " .. spinner .. " " .. table.concat(
+                    series_messages,
+                    ", "
+                ))
             or nil
     end,
 


### PR DESCRIPTION
relate: #95 , #98 , #101 


In previous commit: https://github.com/linrongbin16/lsp-progress.nvim/commit/d7d124a4f78f0eda7d7395b8bd25d655a632e936#diff-cac8a6172f06fbcdb207c376794e53c7dbf871846e643ecd5448c16f75444278R115, I rewrite the default `client_format` with lua's `string.format`, that should be the real root cause.


When formatting strings, should not use lua `string.format` to do it, just use `..` to append the string.