### PR TITLE
fix: correct vim.lsp.client_is_stopped deprecation

### DIFF
--- a/lua/lsp-progress/api.lua
+++ b/lua/lsp-progress/api.lua
@@ -16,9 +16,9 @@ end
 --- @return boolean
 M.lsp_client_is_stopped = function(client_id)
     if NVIM_VERSION_012 then
-        return vim.lsp.client_is_stopped(client_id)
-    else
         return vim.lsp.get_client_by_id(client_id) == nil
+    else
+        return vim.lsp.client_is_stopped(client_id)
     end
 end
 


### PR DESCRIPTION
this fix appears to have been mistakenly applied in reverse
I am getting the following warning, pointing to this file:

```
- ⚠️ WARNING vim.lsp.client_is_stopped() is deprecated. Feature will be removed in Nvim 0.14
  - ADVICE:
    - use vim.lsp.get_client_by_id() instead.
```

this change fixes the warning